### PR TITLE
避免创建python版本为2的虚拟环境

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: gluon
 dependencies:
-- python
+- python=3.5
 - jupyter
 - matplotlib
 - pandas

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: gluon
 dependencies:
-- python=3.5
+- python=3
 - jupyter
 - matplotlib
 - pandas


### PR DESCRIPTION
gluon应该是基于python3开发，但由于很多人默认的python版本为python2，直接使用`conda env create -f environment.yml`则会创建python2为版本的虚拟环境。这样会带来很多不便，如
 https://discuss.gluon.ai/t/topic/3399/9 和 https://discuss.gluon.ai/t/topic/2511/45?u=hlnull 。

在environment.yaml中设定python版本应该可以强制安装python3的虚拟环境。