### PR TITLE
remove unnecessary Dense from mlp-gluon net

### DIFF
--- a/chapter_deep-learning-basics/mlp-gluon.md
+++ b/chapter_deep-learning-basics/mlp-gluon.md
@@ -18,7 +18,6 @@ from mxnet.gluon import loss as gloss, nn
 net = nn.Sequential()
 net.add(nn.Dense(256, activation='relu'))
 net.add(nn.Dense(10))
-net.add(nn.Dense(10))
 net.initialize(init.Normal(sigma=0.01))
 ```
 


### PR DESCRIPTION
Change-Id: I4f410d7fb6e58201628e646b7a167ba4af11c92f

Found the running result on tutorial is not good (Tutorial link https://zh.gluon.ai/chapter_deep-learning-basics/mlp-gluon.html).

After investigation, I think **the second "net.add(nn.Dense(10))" in the sector In[2] is not necessary, and need remove it**, as:
**1. it's not the design as the early text and diagram.
2. there will be a bigger parameter dict here.**
    Before remove the second "net.add(nn.Dense(10))", net.collect_params() returns:
    sequential0_ (
      Parameter dense0_weight (shape=(256, 784), dtype=float32)
      Parameter dense0_bias (shape=(256,), dtype=float32)
      Parameter dense1_weight (shape=(10, 256), dtype=float32)
      Parameter dense1_bias (shape=(10,), dtype=float32)
      Parameter dense2_weight (shape=(10, 10), dtype=float32)
      Parameter dense2_bias (shape=(10,), dtype=float32)
    )
   After remove the second "net.add(nn.Dense(10))", net.collect_params() returns:
   sequential2_ (
      Parameter dense5_weight (shape=(256, 784), dtype=float32)
      Parameter dense5_bias (shape=(256,), dtype=float32)
      Parameter dense6_weight (shape=(10, 256), dtype=float32)
      Parameter dense6_bias (shape=(10,), dtype=float32)
   )
**3. the performance and result became better after remove one layer.**
The current result on tutorial link is:
    epoch 1, loss 2.3884, train acc 0.177, test acc 0.187
    epoch 2, loss 1.7594, train acc 0.285, test acc 0.391
    epoch 3, loss 1.6040, train acc 0.335, test acc 0.412
    epoch 4, loss 1.9488, train acc 0.292, test acc 0.261
    epoch 5, loss 1.4086, train acc 0.407, test acc 0.454
Result on my environment before remove the second "net.add(nn.Dense(10))" is:
    epoch 1, loss 1.2782, train acc 0.505, test acc 0.759
    epoch 2, loss 0.6008, train acc 0.772, test acc 0.828
    epoch 3, loss 0.5001, train acc 0.814, test acc 0.821
    epoch 4, loss 0.4502, train acc 0.831, test acc 0.841
    epoch 5, loss 0.4067, train acc 0.849, test acc 0.863
Result on my environment after remove the second "net.add(nn.Dense(10))" is:
    epoch 1, loss 0.8174, train acc 0.695, test acc 0.819
    epoch 2, loss 0.4974, train acc 0.815, test acc 0.829
    epoch 3, loss 0.4278, train acc 0.841, test acc 0.856
    epoch 4, loss 0.3958, train acc 0.854, test acc 0.846
    epoch 5, loss 0.3696, train acc 0.865, test acc 0.867


