### PR TITLE
Update Jenkinsfile for CI server conda upgrade

### DIFF
--- a/build/build_doc.sh
+++ b/build/build_doc.sh
@@ -25,7 +25,7 @@ cd ..
 # prepare the env
 conda env update -f build/build.yml
 
-source activate gluon_zh_docs
+conda activate gluon_zh_docs
 
 pip list
 


### PR DESCRIPTION
Starting with conda v4.4, `source activate` is discouraged. The CI server now runs conda 4.5 so the Jenkinsfile needs to be adapted.