### PR TITLE
fix typo in ndarray/numpy transform example

### DIFF
--- a/chapter_prerequisite/ndarray.md
+++ b/chapter_prerequisite/ndarray.md
@@ -212,7 +212,7 @@ id(x) == before
 import numpy as np
 
 p = np.ones((2, 3))
-d = nd.array(x)
+d = nd.array(p)
 d
 ```
 


### PR DESCRIPTION
2.2.6小节，在展示`numpy.array`转换为`mx.nd.ndarray`的时候，没有使用刚刚新建的`numpy`数组`p`，而是上节中的`x`。如下所示：

```
import numpy as np
p = np.ones((2, 3))
d = nd.array(x)
d
```
应该改为：
```
import numpy as np
p = np.ones((2, 3))
d = nd.array(p)
d
```
见论坛讨论链接：https://discuss.gluon.ai/t/topic/7429/23?u=crazyai